### PR TITLE
adds support for bower if bower.json exists

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,7 @@ else
 fi
 
 if [ -f bower.json ]; then
+  npm install -g bower
   bower install
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,5 +16,9 @@ else
   yarn install
 fi
 
+if [ -f bower.json ]; then
+  bower install
+fi
+
 echo "Starting ember server: "
 ember server


### PR DESCRIPTION
Even though my project is on Ember CLI 2.16, we still use bower since the app started back when bower was used and we haven't migrated things over to npm yet. I imagine other people with long-lived ember apps might be in a similar situation.